### PR TITLE
initial commit of skymapper_dr2_create_indexes_fkey.sql

### DIFF
--- a/schema/sdss5db/catalogdb/skymapper/dr2/skymapper_dr2_create_indexes_fkey.sql
+++ b/schema/sdss5db/catalogdb/skymapper/dr2/skymapper_dr2_create_indexes_fkey.sql
@@ -1,0 +1,6 @@
+-- create indexes on foreign key columns
+\o skymapper_dr2_create_indexes_fkey.out
+create index on catalogdb.skymapper_dr2(allwise_cntr);
+create index on catalogdb.skymapper_dr2(gaia_dr2_id1);
+create index on catalogdb.skymapper_dr2(gaia_dr2_id2);
+\o


### PR DESCRIPTION
skymapper_dr2_create_indexes_fkey.sql creates indexes on foreign key columns
