### PR TITLE
add design mode and obs mode tables

### DIFF
--- a/python/sdssdb/peewee/sdss5db/targetdb.py
+++ b/python/sdssdb/peewee/sdss5db/targetdb.py
@@ -130,10 +130,10 @@ class Design(TargetdbBase):
                             null=True)
     exposure = IntegerField(null=True)
     pk = AutoField()
-    design_mode = ForeignKeyField(column_name='design_mode_pk',
-                            field='label',
-                            model=DesignMode,
-                            null=True)
+    design_mode_pk = ForeignKeyField(column_name='design_mode_pk',
+                                     field='label',
+                                     model=DesignMode,
+                                     null=True)
 
     class Meta:
         table_name = 'design'

--- a/python/sdssdb/peewee/sdss5db/targetdb.py
+++ b/python/sdssdb/peewee/sdss5db/targetdb.py
@@ -38,6 +38,17 @@ class Version(TargetdbBase):
         table_name = 'version'
 
 
+class ObsMode(TargetdbBase):
+    label = TextField(null=False)
+    min_moon_sep = FloatField(null=True)
+    min_deltaV_KS91 = FloatField(null=True)
+    min_twilight_ang = FloatField(null=True)
+    max_airmass = FloatField(null=True)
+
+    class Meta:
+        table_name = 'obsmode'
+
+
 class Cadence(TargetdbBase):
     label = TextField(null=False)
     nepochs = IntegerField(null=True)
@@ -47,8 +58,9 @@ class Cadence(TargetdbBase):
     # instrument_pk = ArrayField(field_class=IntegerField, null=True)
     nexp = ArrayField(field_class=SmallIntegerField, null=True)
     pk = AutoField()
-    skybrightness = ArrayField(field_class=FloatField, null=True)
+    # skybrightness = ArrayField(field_class=FloatField, null=True)
     max_length = ArrayField(field_class=FloatField, null=True)
+    obsmode_pk = ArrayField(field_class=TextField, null=True)
 
     class Meta:
         table_name = 'cadence'
@@ -85,6 +97,32 @@ class Field(TargetdbBase):
         table_name = 'field'
 
 
+class DesignMode(TargetdbBase):
+    label = TextField(null=False)
+    BOSS_skies_min = IntegerField(null=True)
+    BOSS_skies_FOV = ArrayField(field_class=DoubleField, null=True)
+    APOGEE_skies_min = IntegerField(null=True)
+    APOGEE_skies_FOV = ArrayField(field_class=DoubleField, null=True)
+    BOSS_stds_min = IntegerField(null=True)
+    BOSS_stds_mags_min = ArrayField(field_class=DoubleField, null=True)
+    BOSS_stds_mags_max = ArrayField(field_class=DoubleField, null=True)
+    BOSS_stds_FOV = ArrayField(field_class=DoubleField, null=True)
+    APOGEE_stds_min = IntegerField(null=True)
+    APOGEE_stds_mags_min = ArrayField(field_class=DoubleField, null=True)
+    APOGEE_stds_mags_max = ArrayField(field_class=DoubleField, null=True)
+    APOGEE_stds_FOV = ArrayField(field_class=DoubleField, null=True)
+    BOSS_bright_limit_targets_min = ArrayField(field_class=DoubleField, null=True)
+    BOSS_bright_limit_targets_max = ArrayField(field_class=DoubleField, null=True)
+    BOSS_sky_neighbors_targets = ArrayField(field_class=DoubleField, null=True)
+    APOGEE_bright_limit_targets_min = ArrayField(field_class=DoubleField, null=True)
+    APOGEE_bright_limit_targets_max = ArrayField(field_class=DoubleField, null=True)
+    APOGGE_trace_diff_targets = ArrayField(field_class=DoubleField, null=True)
+    APOGEE_sky_neighbors_targets = ArrayField(field_class=DoubleField, null=True)
+
+    class Meta:
+        table_name = 'design_mode'
+
+
 class Design(TargetdbBase):
     field = ForeignKeyField(column_name='field_pk',
                             field='pk',
@@ -92,6 +130,10 @@ class Design(TargetdbBase):
                             null=True)
     exposure = IntegerField(null=True)
     pk = AutoField()
+    design_mode = ForeignKeyField(column_name='design_mode_pk',
+                            field='label',
+                            model=DesignMode,
+                            null=True)
 
     class Meta:
         table_name = 'design'

--- a/schema/sdss5db/targetdb/targetdb.sql
+++ b/schema/sdss5db/targetdb/targetdb.sql
@@ -90,7 +90,7 @@ create table targetdb.cadence(
     nexp integer[], -- format = '15J' old name was nexposures
     max_length real[], -- format = '15E'
     pk serial primary key,
-    obsmode_pk integer[]
+    obsmode_pk text[]
 );
 
 CREATE TABLE targetdb.instrument (
@@ -131,7 +131,7 @@ CREATE TABLE targetdb.design (
     pk SERIAL PRIMARY KEY NOT NULL,
     exposure BIGINT,
     field_pk INTEGER,
-    design_mode_pk INTEGER);
+    design_mode_pk TEXT);
 
 CREATE TABLE targetdb.field (
     pk SERIAL PRIMARY KEY NOT NULL,
@@ -147,16 +147,14 @@ CREATE TABLE targetdb.field (
     observatory_pk SMALLINT);
 
 CREATE TABLE targetdb.obsmode(
-    pk SERIAL PRIMARY KEY NOT NULL,
-    label TEXT NOT NULL,
+    label TEXT PRIMARY KEY NOT NULL,
     min_moon_sep REAL,
     min_deltaV_KS91 REAL,
     min_twilight_ang REAL,
     max_airmass REAL);
 
 CREATE TABLE targetdb.design_mode(
-    pk SERIAL PRIMARY KEY NOT NULL,
-    label TEXT NOT NULL,
+    label TEXT PRIMARY KEY NOT NULL,
     BOSS_skies_min INTEGER ,
     BOSS_skies_FOV DOUBLE PRECISION[],
     APOGEE_skies_min INTEGER ,
@@ -292,7 +290,7 @@ ALTER TABLE ONLY targetdb.magnitude
 
 ALTER TABLE ONLY targetdb.design
     ADD CONSTRAINT design_mode_fk
-    FOREIGN KEY (design_mode_pk) REFERENCES targetdb.design_mode(pk);
+    FOREIGN KEY (design_mode_pk) REFERENCES targetdb.design_mode(label);
 
 -- Indices
 

--- a/schema/sdss5db/targetdb/targetdb.sql
+++ b/schema/sdss5db/targetdb/targetdb.sql
@@ -84,12 +84,13 @@ create table targetdb.cadence(
     label text not null, -- format = '40A'
     nepochs integer, -- format = 'J'
     delta double precision[], -- format = '15D'
-    skybrightness real[], -- format = '15E'
+    -- skybrightness real[], -- format = '15E'
     delta_max real[], -- format = '15E'
     delta_min real[], -- format = '15E'
     nexp integer[], -- format = '15J' old name was nexposures
     max_length real[], -- format = '15E'
-    pk serial primary key
+    pk serial primary key,
+    obsmode_pk integer[]
 );
 
 CREATE TABLE targetdb.instrument (
@@ -129,7 +130,8 @@ CREATE TABLE targetdb.assignment (
 CREATE TABLE targetdb.design (
     pk SERIAL PRIMARY KEY NOT NULL,
     exposure BIGINT,
-    field_pk INTEGER);
+    field_pk INTEGER,
+    design_mode_pk INTEGER);
 
 CREATE TABLE targetdb.field (
     pk SERIAL PRIMARY KEY NOT NULL,
@@ -144,6 +146,36 @@ CREATE TABLE targetdb.field (
     cadence_pk SMALLINT,
     observatory_pk SMALLINT);
 
+CREATE TABLE targetdb.obsmode(
+    pk SERIAL PRIMARY KEY NOT NULL,
+    label TEXT NOT NULL,
+    min_moon_sep REAL,
+    min_deltaV_KS91 REAL,
+    min_twilight_ang REAL,
+    max_airmass REAL);
+
+CREATE TABLE targetdb.design_mode(
+    pk SERIAL PRIMARY KEY NOT NULL,
+    label TEXT NOT NULL,
+    BOSS_skies_min INTEGER ,
+    BOSS_skies_FOV DOUBLE PRECISION[],
+    APOGEE_skies_min INTEGER ,
+    APOGEE_skies_FOV DOUBLE PRECISION[],
+    BOSS_stds_min INTEGER,
+    BOSS_stds_mags_min DOUBLE PRECISION[],
+    BOSS_stds_mags_max DOUBLE PRECISION[],
+    BOSS_stds_FOV DOUBLE PRECISION[],
+    APOGEE_stds_min INTEGER ,
+    APOGEE_stds_mags_min DOUBLE PRECISION[],
+    APOGEE_stds_mags_max DOUBLE PRECISION[],
+    APOGEE_stds_FOV DOUBLE PRECISION[],
+    BOSS_bright_limit_targets_min DOUBLE PRECISION[],
+    BOSS_bright_limit_targets_max DOUBLE PRECISION[],
+    BOSS_sky_neighbors_targets DOUBLE PRECISION[],
+    APOGEE_bright_limit_targets_min DOUBLE PRECISION[],
+    APOGEE_bright_limit_targets_max DOUBLE PRECISION[],
+    APOGGE_trace_diff_targets DOUBLE PRECISION[] ,
+    APOGEE_sky_neighbors_targets DOUBLE PRECISION[])
 
 -- Table data
 
@@ -258,6 +290,9 @@ ALTER TABLE ONLY targetdb.magnitude
     ON UPDATE CASCADE ON DELETE CASCADE
     DEFERRABLE INITIALLY DEFERRED;
 
+ALTER TABLE ONLY targetdb.design
+    ADD CONSTRAINT design_mode_fk
+    FOREIGN KEY (design_mode_pk) REFERENCES targetdb.design_mode(pk);
 
 -- Indices
 


### PR DESCRIPTION
Adds 2 tables: obsmode and design_mode. They match the specs send around on mailing lists, with the change of a 2xN array for min/max to separate min and max columns.

Also adds the appropriate foreign key relationship for design, and changes the skybrightness array in cadence to obsmode_pk array. Note that explicit foreign key constraints for array elements are not allowed.