### PR TITLE
Do not cache database fields

### DIFF
--- a/python/sdssdb/peewee/__init__.py
+++ b/python/sdssdb/peewee/__init__.py
@@ -148,7 +148,7 @@ class ReflectMeta(ModelBase):
 
         # Lists tables in the schema. This is a bit of a hack but
         # faster than using database.table_exists because it's cached.
-        database.get_fields(table_name, schema)  # Force caching of _metadata.
+        database.get_fields(table_name, schema, cache=False)  # Force caching of _metadata.
         schema_tables = database._metadata[schema].keys()
 
         if table_name not in schema_tables:

--- a/python/sdssdb/peewee/__init__.py
+++ b/python/sdssdb/peewee/__init__.py
@@ -148,7 +148,10 @@ class ReflectMeta(ModelBase):
 
         # Lists tables in the schema. This is a bit of a hack but
         # faster than using database.table_exists because it's cached.
-        database.get_fields(table_name, schema, cache=False)  # Force caching of _metadata.
+        # NOTE: JSG: I'm disabling caching for now because it seems to
+        # prevent reflection working on tables that change dynamically.
+        # In the future we should find a better way.
+        database.get_fields(table_name, schema, cache=False)
         schema_tables = database._metadata[schema].keys()
 
         if table_name not in schema_tables:


### PR DESCRIPTION
Cachins was preventing reflection from working correctly with tables whose columns change dynamically during runtime.