### PR TITLE
Merge Request to Add DesignModeCheckResults Table

### DIFF
--- a/python/sdssdb/peewee/sdss5db/targetdb.py
+++ b/python/sdssdb/peewee/sdss5db/targetdb.py
@@ -154,7 +154,16 @@ class DesignModeValue(TargetdbBase):
                              column_name='design_id',
                              field='design_id',
                              backref="design_mode_values")
-    design_pass = BooleanField(null=True)
+    # whether or not design passes recent
+    # validation and should be observed
+    design_pass = BooleanField(null=False)
+
+    # bitmask to describe current status of
+    # design validation
+    design_status = IntegerField(null=True)
+
+    # values and passing status for design-wide
+    # designmode criteria
     boss_skies_min_pass = BooleanField(null=True)
     boss_skies_min_value = IntegerField(null=True)
     boss_skies_fov_pass = BooleanField(null=True)

--- a/python/sdssdb/peewee/sdss5db/targetdb.py
+++ b/python/sdssdb/peewee/sdss5db/targetdb.py
@@ -181,6 +181,16 @@ class DesignModeCheckResults(TargetdbBase):
     apogee_stds_fov_pass = BooleanField(null=True)
     apogee_stds_fov_value = DoubleField(null=True)
 
+    # just passing status for target-specific
+    # designmode criteria
+    boss_stds_mags_pass = BooleanField(null=True)
+    apogee_stds_mags_pass = BooleanField(null=True)
+    boss_bright_limit_targets_pass = BooleanField(null=True)
+    apogee_bright_limit_targets_pass = BooleanField(null=True)
+    boss_sky_neighbors_targets_pass = BooleanField(null=True)
+    apogee_sky_neighbors_targets_pass = BooleanField(null=True)
+    apogee_trace_diff_targets_pass = BooleanField(null=True)
+
     class Meta:
         table_name = 'design_mode_value'
 

--- a/python/sdssdb/peewee/sdss5db/targetdb.py
+++ b/python/sdssdb/peewee/sdss5db/targetdb.py
@@ -148,6 +148,25 @@ class Design(TargetdbBase):
         table_name = 'design'
 
 
+class DesignModeValue(TargetdbBase):
+    pk = IntegerField(null=False, primary_key=True)
+    design = ForeignKeyField(Design,
+                             column_name='design_id',
+                             field='design_id',
+                             backref="design_mode_values")
+    boss_skies_min_value = IntegerField(null=True)
+    boss_skies_fov_value = DoubleField(null=True)
+    apogee_skies_min_value = IntegerField(null=True)
+    apogee_skies_fov_value = DoubleField(null=True)
+    boss_stds_min_value = IntegerField(null=True)
+    boss_stds_fov_value = DoubleField(null=True)
+    apogee_stds_min_value = IntegerField(null=True)
+    apogee_stds_fov_value = DoubleField(null=True)
+
+    class Meta:
+        table_name = 'design_mode_value'
+
+
 class Instrument(TargetdbBase):
     label = TextField(null=True)
     pk = AutoField()

--- a/python/sdssdb/peewee/sdss5db/targetdb.py
+++ b/python/sdssdb/peewee/sdss5db/targetdb.py
@@ -148,7 +148,7 @@ class Design(TargetdbBase):
         table_name = 'design'
 
 
-class DesignModeValue(TargetdbBase):
+class DesignModeCheckResults(TargetdbBase):
     pk = IntegerField(null=False, primary_key=True)
     design = ForeignKeyField(Design,
                              column_name='design_id',

--- a/python/sdssdb/peewee/sdss5db/targetdb.py
+++ b/python/sdssdb/peewee/sdss5db/targetdb.py
@@ -154,13 +154,22 @@ class DesignModeValue(TargetdbBase):
                              column_name='design_id',
                              field='design_id',
                              backref="design_mode_values")
+    design_pass = BooleanField(null=True)
+    boss_skies_min_pass = BooleanField(null=True)
     boss_skies_min_value = IntegerField(null=True)
+    boss_skies_fov_pass = BooleanField(null=True)
     boss_skies_fov_value = DoubleField(null=True)
+    apogee_skies_min_pass = BooleanField(null=True)
     apogee_skies_min_value = IntegerField(null=True)
+    apogee_skies_fov_pass = BooleanField(null=True)
     apogee_skies_fov_value = DoubleField(null=True)
+    boss_stds_min_pass = BooleanField(null=True)
     boss_stds_min_value = IntegerField(null=True)
+    boss_stds_fov_pass = BooleanField(null=True)
     boss_stds_fov_value = DoubleField(null=True)
+    apogee_stds_min_pass = BooleanField(null=True)
     apogee_stds_min_value = IntegerField(null=True)
+    apogee_stds_fov_pass = BooleanField(null=True)
     apogee_stds_fov_value = DoubleField(null=True)
 
     class Meta:


### PR DESCRIPTION
I have finished adding the parameters for a new table (DesignModeCheckResults) in targetdb that will list design-wide designmode values and pass/fail indicators from the validation of designs. It should be completed and ready to merge if interested parties are satisfied with the layout of the table (mainly @tdwelly, @kevincovey and @blanton144 ?).

The table in question is:

```
class DesignModeCheckResults(TargetdbBase):
    pk = IntegerField(null=False, primary_key=True)
    design = ForeignKeyField(Design,
                             column_name='design_id',
                             field='design_id',
                             backref="design_mode_values")
    # whether or not design passes recent
    # validation and should be observed
    design_pass = BooleanField(null=False)


    # bitmask to describe current status of
    # design validation
    design_status = IntegerField(null=True)


    # values and passing status for design-wide
    # designmode criteria
    boss_skies_min_pass = BooleanField(null=True)
    boss_skies_min_value = IntegerField(null=True)
    boss_skies_fov_pass = BooleanField(null=True)
    boss_skies_fov_value = DoubleField(null=True)
    apogee_skies_min_pass = BooleanField(null=True)
    apogee_skies_min_value = IntegerField(null=True)
    apogee_skies_fov_pass = BooleanField(null=True)
    apogee_skies_fov_value = DoubleField(null=True)
    boss_stds_min_pass = BooleanField(null=True)
    boss_stds_min_value = IntegerField(null=True)
    boss_stds_fov_pass = BooleanField(null=True)
    boss_stds_fov_value = DoubleField(null=True)
    apogee_stds_min_pass = BooleanField(null=True)
    apogee_stds_min_value = IntegerField(null=True)
    apogee_stds_fov_pass = BooleanField(null=True)
    apogee_stds_fov_value = DoubleField(null=True)
```