### PR TITLE
add hash to design table

### DIFF
--- a/python/sdssdb/peewee/sdss5db/targetdb.py
+++ b/python/sdssdb/peewee/sdss5db/targetdb.py
@@ -11,7 +11,7 @@ import datetime
 from peewee import (SQL, AutoField, BigIntegerField, BooleanField,
                     DateTimeField, DeferredThroughModel, DoubleField,
                     FloatField, ForeignKeyField, IntegerField,
-                    SmallIntegerField, TextField, fn)
+                    SmallIntegerField, TextField, fn, UUIDField)
 from playhouse.postgres_ext import ArrayField
 
 from .. import BaseModel
@@ -164,6 +164,7 @@ class Design(TargetdbBase):
                                   null=True)
     mugatu_version = TextField()
     run_on = DateTimeField(default=datetime.datetime.now())
+    asignment_hash = UUIDField()
 
     class Meta:
         table_name = 'design'

--- a/schema/sdss5db/targetdb/targetdb.sql
+++ b/schema/sdss5db/targetdb/targetdb.sql
@@ -127,7 +127,8 @@ CREATE TABLE targetdb.design (
     field_pk INTEGER,
     design_mode_label TEXT,
     mugatu_version TEXT,
-    run_on DATE);
+    run_on DATE,
+    asignment_hash UUID);
 
 CREATE TABLE targetdb.field (
     pk SERIAL PRIMARY KEY NOT NULL,

--- a/schema/sdss5db/targetdb/targetdb.sql
+++ b/schema/sdss5db/targetdb/targetdb.sql
@@ -382,3 +382,7 @@ CREATE INDEX CONCURRENTLY hole_observatory_pk_idx
 CREATE INDEX CONCURRENTLY hole_holeid_idx
     ON targetdb.hole
     USING BTREE(holeid);
+
+CREATE INDEX CONCURRENTLY asignment_hash_idx
+    ON targetdb.design
+    USING BTREE(asignment_hash);


### PR DESCRIPTION
The UUID type is a 16 byte type in postgres that is well suited to an MD5 hash. Peewee supports uuid as well which is nice. psycopg2 treats uuid as a string when inserting to the db.