### PR TITLE
Offset boolean column in carton_to_target

### DIFF
--- a/python/sdssdb/peewee/sdss5db/targetdb.py
+++ b/python/sdssdb/peewee/sdss5db/targetdb.py
@@ -317,6 +317,7 @@ class CartonToTarget(TargetdbBase):
                                  field='pk')
     delta_ra = DoubleField()
     delta_dec = DoubleField()
+    offset = BooleanField(default=False)
     inertial = BooleanField()
 
     class Meta:

--- a/schema/sdss5db/targetdb/targetdb.sql
+++ b/schema/sdss5db/targetdb/targetdb.sql
@@ -68,7 +68,7 @@ CREATE TABLE targetdb.carton_to_target (
     instrument_pk INTEGER,
     delta_ra DOUBLE PRECISION,
     delta_dec DOUBLE PRECISION,
-    offset BOOLEAN,
+    offset BOOLEAN DEFAULT false,
     intertial BOOLEAN,
     value REAL,
     carton_pk SMALLINT,

--- a/schema/sdss5db/targetdb/targetdb.sql
+++ b/schema/sdss5db/targetdb/targetdb.sql
@@ -68,6 +68,7 @@ CREATE TABLE targetdb.carton_to_target (
     instrument_pk INTEGER,
     delta_ra DOUBLE PRECISION,
     delta_dec DOUBLE PRECISION,
+    offset BOOLEAN,
     intertial BOOLEAN,
     value REAL,
     carton_pk SMALLINT,


### PR DESCRIPTION
@albireox , I added the offset boolean column to the carton_to_target table. One question before merging is I set the default value to False (which seemed reasonable) in the python class, but is there a similar kind of setting for this in targetdb.sql? Sorry I am not as familiar with that latter file.