### PR TITLE
add design_version column to targetdb.design

### DIFF
--- a/python/sdssdb/peewee/sdss5db/targetdb.py
+++ b/python/sdssdb/peewee/sdss5db/targetdb.py
@@ -165,6 +165,9 @@ class Design(TargetdbBase):
     mugatu_version = TextField()
     run_on = DateTimeField(default=datetime.datetime.now())
     assignment_hash = UUIDField()
+    version = ForeignKeyField(column_name='design_version',
+                              field='pk',
+                              model=Version)
     # field_exposure = IntegerField()
 
     class Meta:

--- a/python/sdssdb/peewee/sdss5db/targetdb.py
+++ b/python/sdssdb/peewee/sdss5db/targetdb.py
@@ -165,7 +165,7 @@ class Design(TargetdbBase):
     mugatu_version = TextField()
     run_on = DateTimeField(default=datetime.datetime.now())
     assignment_hash = UUIDField()
-    version = ForeignKeyField(column_name='design_version',
+    version = ForeignKeyField(column_name='design_version_pk',
                               field='pk',
                               model=Version)
     # field_exposure = IntegerField()

--- a/schema/sdss5db/targetdb/targetdb.sql
+++ b/schema/sdss5db/targetdb/targetdb.sql
@@ -130,7 +130,7 @@ CREATE TABLE targetdb.design (
     mugatu_version TEXT,
     run_on DATE,
     assignment_hash UUID,
-    design_version SMALLINT);
+    design_version_pk SMALLINT);
     -- field_exposure BIGINT);
 
 CREATE TABLE targetdb.field (
@@ -322,7 +322,7 @@ ALTER TABLE ONLY targetdb.design
 
 ALTER TABLE ONLY targetdb.design
     ADD CONSTRAINT design_version_fk
-    FOREIGN KEY (design_version) REFERENCES targetdb.version(pk)
+    FOREIGN KEY (design_version_pk) REFERENCES targetdb.version(pk)
     ON UPDATE CASCADE ON DELETE CASCADE;
 
 ALTER TABLE ONLY targetdb.design_mode_check_results

--- a/schema/sdss5db/targetdb/targetdb.sql
+++ b/schema/sdss5db/targetdb/targetdb.sql
@@ -129,7 +129,8 @@ CREATE TABLE targetdb.design (
     design_mode_label TEXT,
     mugatu_version TEXT,
     run_on DATE,
-    assignment_hash UUID);
+    assignment_hash UUID,
+    design_version SMALLINT);
     -- field_exposure BIGINT);
 
 CREATE TABLE targetdb.field (

--- a/schema/sdss5db/targetdb/targetdb.sql
+++ b/schema/sdss5db/targetdb/targetdb.sql
@@ -320,6 +320,11 @@ ALTER TABLE ONLY targetdb.design
     ADD CONSTRAINT design_mode_fk
     FOREIGN KEY (design_mode_label) REFERENCES targetdb.design_mode(label);
 
+ALTER TABLE ONLY targetdb.design
+    ADD CONSTRAINT design_version_fk
+    FOREIGN KEY (design_version) REFERENCES targetdb.version(pk)
+    ON UPDATE CASCADE ON DELETE CASCADE;
+
 ALTER TABLE ONLY targetdb.design_mode_check_results
     ADD CONSTRAINT design_id_fk
     FOREIGN KEY (design_id) REFERENCES targetdb.design(design_id);


### PR DESCRIPTION
I have added a new column in targetdb.design called design_version, which is a fk reference to targetdb.version. This column needed to be added so we could track the version of robostrategy a design was created (this could previously be done through a join to targetdb.field, but this has broken down with the addition of targetdb.design_to_field). John I wanted to add you here to make sure these couple changes match what we discussed at the meeting today.