### PR TITLE
Add Design.field attribute

### DIFF
--- a/python/sdssdb/etc/sdssdb.yml
+++ b/python/sdssdb/etc/sdssdb.yml
@@ -16,7 +16,7 @@ lco5:
 apo5:
     user: sdss_user
     admin: sdss
-    host: sdss5-db
+    host: sdss5-db.apo.nmsu.edu
     port: 5432
     domain: sdss5-[a-z0-9]+.apo.nmsu.edu
 


### PR DESCRIPTION
Restores the `Design.field` reference using a property with a custom query instead of a Peewee `ForeignKeyField`.

The logic is:

- If `$RS_VERSION` is not defined, fails.
- If there are multiple fields associated with a design for the same `$RS_VERSION`, fails.
- If there is only one field associated with a design for the RS version, return that one.
- If there are no fields associated with a design for the current RS version, removes the RS field condition and removes the first field (should apply only to commissioning designs without an associated RS run).