### PR TITLE
adds new column to vizdb.sdssid_to_pipes view

### DIFF
--- a/python/sdssdb/peewee/sdss5db/vizdb.py
+++ b/python/sdssdb/peewee/sdss5db/vizdb.py
@@ -61,10 +61,11 @@ class SDSSidToPipes(VizBase):
     in_boss = BooleanField(null=False)
     in_apogee = BooleanField(null=False)
     in_astra = BooleanField(null=False)
+    has_been_observed = BooleanField(null=False)
 
     class Meta:
         table_name = 'sdssid_to_pipes'
-        print_fields = ['sdss_id', 'in_boss', 'in_apogee', 'in_astra']
+        print_fields = ['sdss_id', 'in_boss', 'in_apogee', 'in_astra', 'has_been_observed']
 
 
 class DbMetadata(VizBase):

--- a/python/sdssdb/sqlalchemy/sdss5db/vizdb.py
+++ b/python/sdssdb/sqlalchemy/sdss5db/vizdb.py
@@ -69,13 +69,14 @@ class SDSSidStacked(Base):
 
 class SDSSidToPipes(Base):
     __tablename__ = 'sdssid_to_pipes'
-    print_fields = ['sdss_id', 'in_boss', 'in_apogee', 'in_astra']
+    print_fields = ['sdss_id', 'in_boss', 'in_apogee', 'in_astra', 'has_been_observed']
 
     pk = Column('pk', BigInteger, primary_key=True)
     sdss_id = Column('sdss_id', BigInteger)
     in_boss = Column('in_boss', Boolean)
     in_apogee = Column('in_apogee', Boolean)
     in_astra = Column('in_astra', Boolean)
+    has_been_observed = Column('has_been_observed', Boolean)
 
 
 class Releases(Base):

--- a/schema/sdss5db/metadata/vizdb.json
+++ b/schema/sdss5db/metadata/vizdb.json
@@ -255,6 +255,15 @@
     },
     {
       "schema": "vizdb",
+      "table_name": "sdssid_to_pipes",
+      "column_name": "has_been_observed",
+      "display_name": "Has Been Observed",
+      "sql_type": "boolean",
+      "description": "Flag indicating if the sdss_id target has been observed or not",
+      "unit": "None"
+    },
+    {
+      "schema": "vizdb",
       "table_name": "releases",
       "column_name": "release",
       "display_name": "Data Release",

--- a/schema/sdss5db/vizdb/vizdb.sql
+++ b/schema/sdss5db/vizdb/vizdb.sql
@@ -35,7 +35,7 @@ CLUSTER sdss_id_flat_q3c_ang2ipix_idx ON vizdb.sdss_id_flat;
 ANALYZE vizdb.sdss_id_flat;
 
 
-CREATE MATERIALIZED VIEW vizdb.sdssid_to_pipes2 AS
+CREATE MATERIALIZED VIEW vizdb.sdssid_to_pipes AS
 SELECT row_number() over(order by s.sdss_id) as pk, s.sdss_id,
        (b.sdss_id IS NOT NULL) AS in_boss,
        (v.star_pk IS NOT NULL) AS in_apogee,

--- a/schema/sdss5db/vizdb/vizdb.sql
+++ b/schema/sdss5db/vizdb/vizdb.sql
@@ -35,11 +35,12 @@ CLUSTER sdss_id_flat_q3c_ang2ipix_idx ON vizdb.sdss_id_flat;
 ANALYZE vizdb.sdss_id_flat;
 
 
-CREATE MATERIALIZED VIEW vizdb.sdssid_to_pipes AS
+CREATE MATERIALIZED VIEW vizdb.sdssid_to_pipes2 AS
 SELECT row_number() over(order by s.sdss_id) as pk, s.sdss_id,
        (b.sdss_id IS NOT NULL) AS in_boss,
        (v.star_pk IS NOT NULL) AS in_apogee,
-       (a.sdss_id IS NOT NULL) AS in_astra
+       (a.sdss_id IS NOT NULL) AS in_astra,
+       (b.sdss_id IS NOT NULL OR v.star_pk IS NOT NULL OR a.sdss_id IS NOT NULL) AS has_been_observed
     --    b.id as boss_spectrum_pk,
     --    v.star_pk as apogee_star_pk,
     --    v.visit_pk as apogee_visit_pk,


### PR DESCRIPTION
This PR adds a new `has_been_observed` column to the `vizdb.sdssid_to_pipes` materialized view.  This will allow us or users to filter on targets that have data.  It is a simple boolean based on the existing `in_boss`, `in_apogee`, and `in_astra` columns.  I'm calling any target that has reduced data in at least one of these tables as one that has been observed.