### PR TITLE
Updates to vizdb schema for astra and IPL-4

### DIFF
--- a/python/sdssdb/peewee/sdss5db/__init__.py
+++ b/python/sdssdb/peewee/sdss5db/__init__.py
@@ -17,6 +17,9 @@ class SDSS5dbDatabaseConnection(PeeweeDatabaseConnection):
     dbname = 'sdss5db'
     auto_reflect = False
 
+    # default schema for the astradb
+    astra_schema = 'astra_050'
+
     def post_connect(self):
         """Force reload of catalogdb and targetdb.
 
@@ -37,5 +40,26 @@ class SDSS5dbDatabaseConnection(PeeweeDatabaseConnection):
             if module in sys.modules:
                 importlib.reload(sys.modules[module])
 
+        # ensure current astradb schema is applied after connect
+        try:
+            self.set_astra_schema(self.astra_schema)
+        except Exception:
+            pass
+
+    def set_astra_schema(self, schema: str):
+        """ Dynamically sets the schema for the astradb models."""
+        self.astra_schema = schema
+        module = 'sdssdb.peewee.sdss5db.astradb'
+
+        if module not in sys.modules:
+            return
+
+        mod = importlib.reload(sys.modules[module])
+        # patch peewee model classes: set their _meta.schema
+        for obj in list(vars(mod).values()):
+            meta = getattr(obj, '_meta', None)
+            if meta is not None:
+                # set schema (safe even if already set)
+                setattr(meta, 'schema', schema)
 
 database = SDSS5dbDatabaseConnection()

--- a/python/sdssdb/peewee/sdss5db/boss_drp.py
+++ b/python/sdssdb/peewee/sdss5db/boss_drp.py
@@ -8,16 +8,17 @@
 # Database: sdss5db
 # Peewee version: 3.15.1
 
-
+import operator
+from functools import reduce
 from peewee import (AutoField, BigIntegerField, BigBitField, BooleanField,
                     CharField, DateTimeField, FloatField, ForeignKeyField,
-                    IntegerField, DoubleField, SmallIntegerField)
+                    IntegerField, DoubleField, SmallIntegerField, fn)
 from peewee import SQL
 from playhouse.postgres_ext import ArrayField
+from playhouse.hybrid import hybrid_method
 
 from .. import BaseModel
 from . import database  # noqa
-
 
 class BossBase(BaseModel):
 
@@ -290,6 +291,34 @@ class BossSpectrum(BossBase):
 
     class Meta:
         table_name = 'boss_spectrum'
+
+    @hybrid_method
+    def is_sdss5_target_bit_set(self, bit):
+        """
+        An expression to evaluate whether this source is assigned to the carton with the given bit position.
+
+        :param bit:
+            The carton bit position.
+        """
+        return (
+            (fn.length(self.sdss5_target_flags) > int(bit / 8))
+        &   (fn.get_bit(self.sdss5_target_flags, int(bit)) > 0)
+        )
+
+    @hybrid_method
+    def is_sdss5_target_any_bit_set(self, bits):
+        """
+        An expression to evaluate whether this source is assigned to any of the cartons with the given bit positions.
+
+        :param bits:
+            A list of carton bit positions.
+        """
+        conditions = [
+            (fn.length(self.sdss5_target_flags) > int(bit / 8)) &
+            (fn.get_bit(self.sdss5_target_flags, int(bit)) > 0)
+            for bit in bits
+        ]
+        return reduce(operator.or_, conditions)
 
 
 class BossSpectrumLine(BossBase):

--- a/schema/sdss5db/vizdb/vizdb.sql
+++ b/schema/sdss5db/vizdb/vizdb.sql
@@ -37,34 +37,127 @@ CREATE INDEX sdss_id_flat_radeccat_q3c_ang2ipix_idx on vizdb.sdss_id_flat (q3c_a
 CLUSTER sdss_id_flat_q3c_ang2ipix_idx ON vizdb.sdss_id_flat;
 ANALYZE vizdb.sdss_id_flat;
 
--- this view creates duplicate rows for sdss_ids based on the number of apogee and boss visit spectra
--- the mjd column is the date of observation
+
+-- Refresh the views with the following commands:
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY vizdb.sdss_id_stacked WITH DATA;
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY vizdb.sdss_id_flat WITH DATA;
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY vizdb.astra_sources WITH DATA;
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY vizdb.astra_visits WITH DATA;
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY vizdb.sdssid_to_pipes WITH DATA;
+
+-- helper view of all sources in astra 0.5.0 and 0.8.0
+DROP MATERIALIZED VIEW IF EXISTS vizdb.astra_sources;
+CREATE SEQUENCE IF NOT EXISTS vizdb.astra_sources_pk_seq;
+
+CREATE MATERIALIZED VIEW vizdb.astra_sources AS
+SELECT nextval('vizdb.astra_sources_pk_seq'::regclass) AS pk,
+pk as source_pk, sdss_id, '0.5.0'::text AS v_astra
+FROM astra_050.source
+UNION ALL
+SELECT nextval('vizdb.astra_sources_pk_seq'::regclass) AS pk,
+pk as source_pk, sdss_id, '0.8.0'::text AS v_astra
+FROM astra_080.source
+WITH DATA;
+
+CREATE UNIQUE INDEX CONCURRENTLY ON vizdb.astra_sources USING BTREE(pk);
+CREATE INDEX CONCURRENTLY ON vizdb.astra_sources USING BTREE(sdss_id);
+
+-- helper view of all astra apogee/boss visits across 0.5.0 and 0.8.0
+DROP MATERIALIZED VIEW IF EXISTS vizdb.astra_visits;
+CREATE SEQUENCE IF NOT EXISTS vizdb.astra_visits_pk_seq;
+CREATE MATERIALIZED VIEW vizdb.astra_visits AS
+-- astra apogee visits
+-- 0.5.0
+SELECT nextval('vizdb.astra_visits_pk_seq'::regclass) AS pk,
+   v.source_pk, a.sdss_id, v.release, v.apred as version, v.telescope, v.mjd, 'apogee'::text AS pipeline, '0.5.0'::text AS v_astra
+  FROM astra_050.apogee_visit_spectrum v
+  JOIN astra_050.source a ON v.source_pk = a.pk
+UNION ALL
+-- 0.8.0
+SELECT nextval('vizdb.astra_visits_pk_seq'::regclass) AS pk,
+  v.source_pk, a.sdss_id, v.release, v.apred as version, v.telescope, v.mjd, 'apogee'::text AS pipeline, '0.8.0'::text AS v_astra
+FROM astra_080.apogee_visit_spectrum v
+JOIN astra_080.source a ON v.source_pk = a.pk
+UNION ALL
+-- astra boss visits
+-- 0.5.0
+SELECT nextval('vizdb.astra_visits_pk_seq'::regclass) AS pk,
+   o.source_pk, a.sdss_id, o.release, o.run2d as version, o.telescope, o.mjd, 'boss'::text AS pipeline, '0.5.0'::text AS v_astra
+FROM astra_050.boss_visit_spectrum o
+JOIN astra_050.source a ON o.source_pk = a.pk
+UNION ALL
+-- 0.8.0
+SELECT nextval('vizdb.astra_visits_pk_seq'::regclass) AS pk,
+  o.source_pk, a.sdss_id, o.release, o.run2d as version, o.telescope, o.mjd, 'boss'::text AS pipeline, '0.8.0'::text AS v_astra
+FROM astra_080.boss_visit_spectrum o
+JOIN astra_080.source a ON o.source_pk = a.pk
+WITH DATA;
+
+CREATE UNIQUE INDEX CONCURRENTLY ON vizdb.astra_visits USING BTREE(pk);
+CREATE INDEX CONCURRENTLY ON vizdb.astra_visits(sdss_id);
+CREATE INDEX CONCURRENTLY ON vizdb.astra_visits(mjd);
+
+-- this creates a view of observed sdss_id by apogee or boss visit spectra
+-- mostly one unique row per sdss_id + mjd
+-- there are a few duplicate rows of dr17 spectra of the same target observed
+-- on the same mjd but on different plates.
+-- mjd column is the date of observation from boss_drp, apogee_drp, or astra tables
+DROP MATERIALIZED VIEW IF EXISTS vizdb.sdssid_to_pipes;
 CREATE MATERIALIZED VIEW vizdb.sdssid_to_pipes AS
-SELECT row_number() over(order by s.sdss_id) as pk, s.sdss_id,
-       (b.sdss_id IS NOT NULL) AS in_boss,
-       (v.star_pk IS NOT NULL or v.visit_pk IS NOT NULL) AS in_apogee,
-	   (o.source_pk IS NOT NULL) AS in_bvs,
-       (a.sdss_id IS NOT NULL) AS in_astra,
-       (b.sdss_id IS NOT NULL OR v.source_pk IS NOT NULL OR o.source_pk IS NOT NULL) AS has_been_observed,
-       case when b.sdss_id IS NOT NULL then 'sdss5' when v.source_pk IS NOT NULL then v.release when o.source_pk is NOT NULL then o.release end as release,
-       case when b.sdss_id IS NOT NULL then lower(b.obs) when v.source_pk IS NOT NULL then substring(v.telescope,0,4) when o.source_pk IS NOT NULL then substring(o.telescope,0,4) end as obs,
-       case when b.sdss_id IS NOT NULL then b.mjd when v.source_pk IS NOT NULL then v.mjd when o.source_pk IS NOT NULL then o.mjd end as mjd
-FROM vizdb.sdss_id_stacked AS s
-LEFT JOIN boss_drp.boss_spectrum AS b ON s.sdss_id = b.sdss_id
-LEFT JOIN astra_050.source AS a ON s.sdss_id = a.sdss_id
-LEFT JOIN astra_050.apogee_visit_spectrum as v on v.source_pk=a.pk
-LEFT JOIN astra_050.boss_visit_spectrum as o on o.source_pk=a.pk
+SELECT row_number() over (order by x.sdss_id, x.mjd) as pk, x.*  -- add a unique pk
+FROM (
+SELECT
+  -- reduce duplicate rows to one unique (sdss_id + mjd visit)
+  distinct on (s.sdss_id, o.mjd, lower(o.obs))
+  s.sdss_id,
+
+  -- pipeline presence flags
+  EXISTS (SELECT 1 FROM boss_drp.boss_spectrum b WHERE b.sdss_id = s.sdss_id) AS in_boss,
+  ( EXISTS (SELECT 1 FROM apogee_drp.star ps WHERE ps.sdss_id = s.sdss_id)
+    OR EXISTS (SELECT 1 FROM apogee_drp.visit pv WHERE pv.sdss_id = s.sdss_id)
+  ) AS in_apogee,
+  EXISTS (SELECT 1 FROM vizdb.astra_visits avs WHERE avs.sdss_id = s.sdss_id AND avs.pipeline = 'boss') AS in_bvs,
+  EXISTS (SELECT 1 FROM vizdb.astra_sources a WHERE a.sdss_id = s.sdss_id) AS in_astra,
+
+  -- observed with any pipeline (any visit/obs row recorded)
+  (
+    EXISTS (SELECT 1 FROM boss_drp.boss_spectrum b WHERE b.sdss_id = s.sdss_id)
+    OR EXISTS (SELECT 1 FROM apogee_drp.visit pv WHERE pv.sdss_id = s.sdss_id)
+    OR EXISTS (SELECT 1 FROM vizdb.astra_visits avs WHERE avs.sdss_id = s.sdss_id)
+  ) AS has_been_observed,
+
+  -- release / obs / mjd come from the joined observation rows
+  o.release,
+  lower(o.obs) AS obs,
+  o.mjd
+
+FROM vizdb.sdss_id_stacked s
+LEFT JOIN (
+  -- union all observation sources; produces zero-or-more rows per sdss_id + visit/mjd
+  SELECT b.sdss_id, 'sdss5'::text AS release, b.obs::text AS obs, b.mjd
+  FROM boss_drp.boss_spectrum b
+
+  UNION ALL
+
+  SELECT v.sdss_id, 'sdss5'::text AS release,
+         substring(v.telescope,1,3)::text AS obs,
+         v.mjd
+  FROM apogee_drp.visit v
+
+  UNION ALL
+
+  SELECT avs.sdss_id, avs.release::text AS release,
+         substring(avs.telescope,1,3)::text AS obs,
+         avs.mjd
+  FROM vizdb.astra_visits avs
+) o ON s.sdss_id = o.sdss_id
+order by s.sdss_id, o.mjd ASC NULLS LAST, lower(o.obs)
+) as x
 WITH DATA;
 
 CREATE UNIQUE INDEX CONCURRENTLY ON vizdb.sdssid_to_pipes USING BTREE(pk);
 CREATE INDEX CONCURRENTLY ON vizdb.sdssid_to_pipes USING BTREE(sdss_id);
 CREATE INDEX CONCURRENTLY ON vizdb.sdssid_to_pipes USING BTREE(mjd);
-
-
--- Refresh the views with the following commands:
--- REFRESH MATERIALIZED VIEW CONCURRENTLY vizdb.sdss_id_stacked WITH DATA;
--- REFRESH MATERIALIZED VIEW CONCURRENTLY vizdb.sdss_id_flat WITH DATA;
--- REFRESH MATERIALIZED VIEW CONCURRENTLY vizdb.sdssid_to_pipes WITH DATA;
 
 
 CREATE TABLE vizdb.db_metadata (


### PR DESCRIPTION
This PR updates vizdb schema and ORM to support IPL-4 and astra 0.8.0.  It adds support to dynamically toggle the astra schema during runtime for the Peewee models only, using `db.set_astra_schema`.

It updates the vizdb materialized views to add 2 new views:
 - `astra_sources` - a view of all targets from the source table across 0.5.0 and 0.8.0 schema
 - `astra_visits` - a view of all targets from boss_visit_spectrum and apogee_visit_spectrum across 0.5.0 and 0.8.0 schema
 
It updates the `sdssid_to_pipes` view to pull from these views, along with `apogee_drp.visit` now that the apogee tables have an sdss_id column.  Previously, this table was a cartesian product of all matching rows from the pipeline tables, resulting in a large number of duplicate rows.  This refactors the sql to instead produce one row per sdss_id+mjd visit.  

It also adds hybrid methods to the astra.source and boss_drp.boss_spectrum tables for querying sdss5_target_flags.
