### PR TITLE
Enable lvmopsdb in the sdss5db schema

### DIFF
--- a/python/sdssdb/peewee/sdss5db/lvmopsdb.py
+++ b/python/sdssdb/peewee/sdss5db/lvmopsdb.py
@@ -1,0 +1,1 @@
+../lvmdb/lvmopsdb.py


### PR DESCRIPTION
This feels a little heinous, hence the PR. But it seems quite smooth and seems to work fine? 

Since the lvmopsdb schema exists in the sdss5db database, and the model classes use relative imports to determine the database connection, this does seem to just work? Feel free to test, e.g.

```
from sdssdb.peewee.sdss5db import database
database.set_profile('pipelines')
from sdssdb.peewee.sdss5db import lvmopsdb
tile = lvmopsdb.Tile
test = tile.select().where(tile.ra < 10)
len(t for t in test])
```