### PR TITLE
Tweaks to ORM

### DIFF
--- a/python/sdssdb/peewee/sdss5db/_astra/v080.py
+++ b/python/sdssdb/peewee/sdss5db/_astra/v080.py
@@ -5,6 +5,7 @@
 from peewee import (
     AutoField,
     BigIntegerField,
+    BitField,
     BooleanField,
     DateTimeField,
     FloatField,
@@ -647,7 +648,13 @@ class MwmSpectrumProductStatus(AstraBase):
     t_overhead = FloatField(null=True)
     tag = TextField(index=True)
     v_astra_major_minor = IntegerField()
-    flags = BigIntegerField()
+    flags = BitField(default=0, help_text="Flags for the status of the spectrum products")
+    flag_skipped_because_no_sdss_id = flags.flag(2**0) # "Source was skipped because no SDSS ID exists"
+    flag_skipped_because_not_stellar_like = flags.flag(2**1) # "Source was skipped because it is not stellar-like"
+    flag_attempted_but_exception = flags.flag(2**2) # "An exception was raised during processing"
+    flag_created_mwm_visit = flags.flag(2**3) # "MWM visit spectrum was created"
+    flag_created_mwm_star = flags.flag(2**4) # "MWM star spectrum was created"
+
     class Meta:
         table_name = 'mwm_spectrum_product_status'
         indexes = (

--- a/python/sdssdb/peewee/sdss5db/_astra/v081.py
+++ b/python/sdssdb/peewee/sdss5db/_astra/v081.py
@@ -5,6 +5,7 @@
 from peewee import (
     AutoField,
     BigIntegerField,
+    BitField,
     BooleanField,
     DateTimeField,
     FloatField,
@@ -428,7 +429,13 @@ class MwmSpectrumProductStatus(AstraBase):
     t_overhead = FloatField(null=True)
     tag = TextField(index=True)
     v_astra_major_minor = IntegerField()
-    flags = BigIntegerField()
+    flags = BitField(default=0, help_text="Flags for the status of the spectrum products")
+    flag_skipped_because_no_sdss_id = flags.flag(2**0) # "Source was skipped because no SDSS ID exists"
+    flag_skipped_because_not_stellar_like = flags.flag(2**1) # "Source was skipped because it is not stellar-like"
+    flag_attempted_but_exception = flags.flag(2**2) # "An exception was raised during processing"
+    flag_created_mwm_visit = flags.flag(2**3) # "MWM visit spectrum was created"
+    flag_created_mwm_star = flags.flag(2**4) # "MWM star spectrum was created"
+
     class Meta:
         table_name = 'mwm_spectrum_product_status'
         indexes = (

--- a/python/sdssdb/peewee/sdss5db/vizdb.py
+++ b/python/sdssdb/peewee/sdss5db/vizdb.py
@@ -78,6 +78,7 @@ class SDSSidToPipes(VizBase):
     release = TextField(null=True)
     obs = TextField(null=True)
     mjd = IntegerField(null=True)
+    has_legacy_data = BooleanField(null=False)
 
     class Meta:
         table_name = "sdssid_to_pipes"

--- a/python/sdssdb/sqlalchemy/sdss5db/vizdb.py
+++ b/python/sdssdb/sqlalchemy/sdss5db/vizdb.py
@@ -104,6 +104,7 @@ class SDSSidToPipes(Base):
     release: Mapped[Optional[str]] = mapped_column("release", Text)
     obs: Mapped[Optional[str]] = mapped_column("obs", Text)
     mjd: Mapped[Optional[int]] = mapped_column("mjd", Integer)
+    has_legacy_data: Mapped[Optional[bool]] = mapped_column("has_legacy_data", Boolean)
 
 
 class Releases(Base):

--- a/schema/sdss5db/metadata/vizdb.json
+++ b/schema/sdss5db/metadata/vizdb.json
@@ -317,6 +317,15 @@
     },
     {
       "schema": "vizdb",
+      "table_name": "sdssid_to_pipes",
+      "column_name": "has_legacy_data",
+      "display_name": "Has Legacy Data",
+      "sql_type": "boolean",
+      "description": "Flag indicating if the sdss_id has legacy data available (pre SDSS-V)",
+      "unit": ""
+    },
+    {
+      "schema": "vizdb",
       "table_name": "releases",
       "column_name": "release",
       "display_name": "Data Release",

--- a/schema/sdss5db/vizdb/vizdb.sql
+++ b/schema/sdss5db/vizdb/vizdb.sql
@@ -145,7 +145,15 @@ SELECT
   -- release / obs / mjd come from the joined observation rows
   o.release,
   lower(o.obs) AS obs,
-  o.mjd
+  o.mjd,
+
+  -- has legacy data from pre SDSS-V
+  EXISTS (
+    SELECT 1
+    FROM vizdb.allspec aspec
+    WHERE aspec.sdss_id = s.sdss_id
+      AND aspec.sdss_phase < 5
+  ) AS has_legacy_data
 
 FROM vizdb.sdss_id_stacked s
 LEFT JOIN (
@@ -174,7 +182,7 @@ WITH DATA;
 CREATE UNIQUE INDEX CONCURRENTLY ON vizdb.sdssid_to_pipes USING BTREE(pk);
 CREATE INDEX CONCURRENTLY ON vizdb.sdssid_to_pipes USING BTREE(sdss_id);
 CREATE INDEX CONCURRENTLY ON vizdb.sdssid_to_pipes USING BTREE(mjd);
-
+CREATE INDEX CONCURRENTLY ON vizdb.sdssid_to_pipes USING BTREE(has_legacy_data);
 
 CREATE TABLE vizdb.db_metadata (
     pk SERIAL PRIMARY KEY NOT NULL,


### PR DESCRIPTION
This PR adds a `has_legacy_data` column to the `vizdb.sdssid_to_pipes` view/ORM and also adds flag columns to the Astra MWMProductStatus ORM, copied from the Astra models. 